### PR TITLE
商品一覧表示機能の実装

### DIFF
--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -2,7 +2,7 @@ class ItemsController < ApplicationController
   before_action :move_new_user_session, only: [:new]
 
   def index
-    @item = Item.all.order( created_at: "DESC" )
+    @item = Item.all.order(created_at: 'DESC')
   end
 
   def new
@@ -21,7 +21,7 @@ class ItemsController < ApplicationController
   private
 
   def move_new_user_session
-    redirect_to new_user_session_path unless user_signed_in? 
+    redirect_to new_user_session_path unless user_signed_in?
   end
 
   def item_params

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -2,6 +2,7 @@ class ItemsController < ApplicationController
   before_action :move_new_user_session, only: [:new]
 
   def index
+    @item = Item.all.order( created_at: "DESC" )
   end
 
   def new

--- a/app/views/items/index.html.erb
+++ b/app/views/items/index.html.erb
@@ -156,6 +156,26 @@
       </li>
     <% end %>
 
+    <% if @item.empty? %>
+      <li class='list'>
+        <%= link_to '#' do %>
+        <%= image_tag "https://s3-ap-northeast-1.amazonaws.com/mercarimaster/uploads/captured_image/content/10/a004.png", class: "item-img" %>
+        <div class='item-info'>
+          <h3 class='item-name'>
+            商品を出品してね！
+          </h3>
+          <div class='item-price'>
+            <span>99999999円<br>(税込み)</span>
+            <div class='star-btn'>
+              <%= image_tag "star.png", class:"star-icon" %>
+              <span class='star-count'>0</span>
+            </div>
+          </div>
+        </div>
+        <% end %>
+      </li>
+    <% end %>
+
     </ul>
   </div>
   <%# /商品一覧 %>

--- a/app/views/items/index.html.erb
+++ b/app/views/items/index.html.erb
@@ -125,38 +125,37 @@
     <h2 class='title'>ピックアップカテゴリー</h2>
     <%= link_to '新規投稿商品', "#", class: "subtitle" %>
     <ul class='item-lists'>
+    <% unless @item.empty? %>
+      <% @item.each do |item| %>
+        <li class='list'>
+          <%= link_to "#" do %>
+          <div class='item-img-content'>
+            <%= image_tag item.image, class: "item-img" %>
 
-    <% @item.each do |item| %>
-      <li class='list'>
-        <%= link_to "#" do %>
-        <div class='item-img-content'>
-          <%= image_tag item.image, class: "item-img" %>
+            <%# 商品が売れていればsold outを表示しましょう %>
+          <%# if Purchase.find(item.id) != nil %>
+            <%# <div class='sold-out'>
+              <span>Sold Out!!</span>
+            </div> %>
+          <%# end %>
 
-          <%# 商品が売れていればsold outを表示しましょう %>
-        <%# if Purchase.find(item.id) != nil %>
-          <%# <div class='sold-out'>
-            <span>Sold Out!!</span>
-          </div> %>
-        <%# end %>
-
-        </div>
-        <div class='item-info'>
-          <h3 class='item-name'>
-            <%= item.name %>
-          </h3>
-          <div class='item-price'>
-            <span><%= item.selling_price %>円<br><%= item.delivery_charge_burden.name %></span>
-            <div class='star-btn'>
-              <%= image_tag "star.png", class:"star-icon" %>
-              <span class='star-count'>0</span>
+          </div>
+          <div class='item-info'>
+            <h3 class='item-name'>
+              <%= item.name %>
+            </h3>
+            <div class='item-price'>
+              <span><%= item.selling_price %>円<br><%= item.delivery_charge_burden.name %></span>
+              <div class='star-btn'>
+                <%= image_tag "star.png", class:"star-icon" %>
+                <span class='star-count'>0</span>
+              </div>
             </div>
           </div>
-        </div>
-        <% end %>
-      </li>
-    <% end %>
-
-    <% if @item.empty? %>
+          <% end %>
+        </li>
+      <% end %>
+    <% else %>
       <li class='list'>
         <%= link_to '#' do %>
         <%= image_tag "https://s3-ap-northeast-1.amazonaws.com/mercarimaster/uploads/captured_image/content/10/a004.png", class: "item-img" %>

--- a/app/views/items/index.html.erb
+++ b/app/views/items/index.html.erb
@@ -126,25 +126,26 @@
     <%= link_to '新規投稿商品', "#", class: "subtitle" %>
     <ul class='item-lists'>
 
-      <%# 商品のインスタンス変数になにか入っている場合、中身のすべてを展開できるようにしましょう %>
+    <% @item.each do |item| %>
       <li class='list'>
         <%= link_to "#" do %>
         <div class='item-img-content'>
-          <%= image_tag "item-sample.png", class: "item-img" %>
+          <%= image_tag item.image, class: "item-img" %>
 
           <%# 商品が売れていればsold outを表示しましょう %>
-          <div class='sold-out'>
+        <%# if Purchase.find(item.id) != nil %>
+          <%# <div class='sold-out'>
             <span>Sold Out!!</span>
-          </div>
-          <%# //商品が売れていればsold outを表示しましょう %>
+          </div> %>
+        <%# end %>
 
         </div>
         <div class='item-info'>
           <h3 class='item-name'>
-            <%= "商品名" %>
+            <%= item.name %>
           </h3>
           <div class='item-price'>
-            <span><%= "販売価格" %>円<br><%= '配送料負担' %></span>
+            <span><%= item.selling_price %>円<br><%= item.delivery_charge_burden.name %></span>
             <div class='star-btn'>
               <%= image_tag "star.png", class:"star-icon" %>
               <span class='star-count'>0</span>
@@ -153,29 +154,8 @@
         </div>
         <% end %>
       </li>
-      <%# //商品のインスタンス変数になにか入っている場合、中身のすべてを展開できるようにしましょう %>
+    <% end %>
 
-      <%# 商品がない場合のダミー %>
-      <%# 商品がある場合は表示されないようにしましょう %>
-      <li class='list'>
-        <%= link_to '#' do %>
-        <%= image_tag "https://s3-ap-northeast-1.amazonaws.com/mercarimaster/uploads/captured_image/content/10/a004.png", class: "item-img" %>
-        <div class='item-info'>
-          <h3 class='item-name'>
-            商品を出品してね！
-          </h3>
-          <div class='item-price'>
-            <span>99999999円<br>(税込み)</span>
-            <div class='star-btn'>
-              <%= image_tag "star.png", class:"star-icon" %>
-              <span class='star-count'>0</span>
-            </div>
-          </div>
-        </div>
-        <% end %>
-      </li>
-      <%# //商品がある場合は表示されないようにしましょう %>
-      <%# /商品がない場合のダミー %>
     </ul>
   </div>
   <%# /商品一覧 %>

--- a/spec/models/item_spec.rb
+++ b/spec/models/item_spec.rb
@@ -48,7 +48,7 @@ RSpec.describe Item, type: :model do
       it 'カテゴリーの情報が初期値(id = 1)では登録できない' do
         @item.category_id = 1
         @item.valid?
-        expect(@item.errors.full_messages).to include("Category must be other than 1")
+        expect(@item.errors.full_messages).to include('Category must be other than 1')
       end
       it '商品の状態が空では登録できない' do
         @item.state_id = nil
@@ -58,7 +58,7 @@ RSpec.describe Item, type: :model do
       it '商品の状態が初期値(id = 1)では登録できない' do
         @item.state_id = 1
         @item.valid?
-        expect(@item.errors.full_messages).to include("State must be other than 1")
+        expect(@item.errors.full_messages).to include('State must be other than 1')
       end
       it '配送料の負担が空では登録できない' do
         @item.delivery_charge_burden_id = nil
@@ -68,7 +68,7 @@ RSpec.describe Item, type: :model do
       it '配送料の負担が初期値(id = 1)では登録できない' do
         @item.delivery_charge_burden_id = 1
         @item.valid?
-        expect(@item.errors.full_messages).to include("Delivery charge burden must be other than 1")
+        expect(@item.errors.full_messages).to include('Delivery charge burden must be other than 1')
       end
       it '発送元の地域が空では登録できない' do
         @item.delivery_source_id = nil
@@ -78,7 +78,7 @@ RSpec.describe Item, type: :model do
       it '発送元の地域が初期値(id = 1)では登録できない' do
         @item.delivery_source_id = 1
         @item.valid?
-        expect(@item.errors.full_messages).to include("Delivery source must be other than 1")
+        expect(@item.errors.full_messages).to include('Delivery source must be other than 1')
       end
       it '発送までの日数が空では登録できない' do
         @item.delivery_time_id = nil
@@ -88,7 +88,7 @@ RSpec.describe Item, type: :model do
       it '発送までの日数が初期値(id = 1)では登録できない' do
         @item.delivery_time_id = 1
         @item.valid?
-        expect(@item.errors.full_messages).to include("Delivery time must be other than 1")
+        expect(@item.errors.full_messages).to include('Delivery time must be other than 1')
       end
       it '販売価格が空では登録できない' do
         @item.selling_price = nil


### PR DESCRIPTION
# What
商品一覧表示機能の実装

# Why
出品された商品をトップページに一覧表示を行うため
※soldoutの表示については購入機能実装時に合わせて実装するため、現在はコメントアウトしています。
![88515670fdd8d2b3123cad3dd1c07733](https://user-images.githubusercontent.com/72850080/98495036-a50ab500-2281-11eb-9c04-fee3fdd2189c.gif)

![3d1dfdabda99541271f3a6fdac2a6ec2](https://user-images.githubusercontent.com/72850080/98495053-af2cb380-2281-11eb-9202-70488baa972a.gif)

